### PR TITLE
Add dummy data

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"dependencies": {
 		"gulp": "^3.9.1",
+		"lodash": "^4.17.4",
 		"react": "16.0.0-beta.5",
 		"react-native": "0.49.5",
 		"react-native-swipe-list-view": "^0.4.6",
@@ -24,6 +25,7 @@
 	},
 	"devDependencies": {
 		"@types/jest": "^21.1.5",
+		"@types/lodash": "^4.14.85",
 		"@types/react": "^16.0.19",
 		"@types/react-native": "^0.49.5",
 		"@types/react-navigation": "^1.0.22",

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,6 +1,18 @@
+import { times, sample } from 'lodash';
+
 const DEFAULT_STATE: State = {
-  sessions: [],
-  todos: [],
+  sessions: times(40, num => ({
+    id: num.toString(),
+    duration: num,
+    createdAt: new Date,
+    todoId: sample([0, 1, 2, 3]).toString(),
+  })),
+  todos: times(4, num => ({
+    id: num.toString(),
+    title: `Todo #${num}`,
+    isDone: (num % 2 === 0),
+    createdAt: new Date(),
+  })),
   settings: {
     workInterval: {
       labelKorean: '세션 길이',
@@ -18,26 +30,27 @@ const DEFAULT_STATE: State = {
 }
 
 interface Session {
-  id: String
-  duration: Number
+  id: string
+  duration: number
   createdAt: Date
-  todoId: Number
+  todoId: string,
 }
 
 export interface Todo {
-  title: String
-  isDone: Boolean
+  id: string;
+  title: string
+  isDone: boolean
   createdAt: Date
 }
 
 interface State {
   sessions: Session[]
   todos: Todo[]
-  settings: Object
+  settings: object
 }
 
 export interface Action {
-  type: String
+  type: string
   payload: any
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@
   version "21.1.5"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-21.1.5.tgz#3db93d069d12602ca115d3604550e15131d8eb7a"
 
+"@types/lodash@^4.14.85":
+  version "4.14.85"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.85.tgz#a16fbf942422f6eca5622b6910492c496c35069b"
+
 "@types/react-native@*", "@types/react-native@^0.49.5":
   version "0.49.5"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.49.5.tgz#9941519a97c92ff2c1305a44303558568cee6296"


### PR DESCRIPTION
- 생성자로 타입 지정한 인터페이스들 수정. (원시 타입은 소문자 타입)
- redux에 더미 데이터 추가

close #16